### PR TITLE
style: a 태그 색상 변경

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,3 +80,7 @@ body {
 .sr-only {
   display: none;
 }
+
+a {
+  color: var(--base-400)
+}


### PR DESCRIPTION
링크 된 텍스트의 색상이 배경색 때문에 잘 보이지 않아 a 태그 color 값을 추가합니다.

---

BEFORE
<img width="898" alt="image" src="https://github.com/user-attachments/assets/c9d793da-fcf3-4ec9-92f3-e3b4180ddd9e" />

AFTER
<img width="892" alt="image" src="https://github.com/user-attachments/assets/74b4ee72-28f3-41c3-9880-b3678ec4e098" />