### PR TITLE
redesign: 에디토리얼 IBM Plex 리디자인 (home·아카이브·헤더·카드·검색)

### DIFF
--- a/src/components/Post.astro
+++ b/src/components/Post.astro
@@ -3,19 +3,16 @@ import type { CollectionEntry } from 'astro:content';
 import { env } from 'cloudflare:workers';
 import styles from "@/styles/components/post.module.css";
 
-
 export interface Props {
   post: CollectionEntry<"news">;
 };
 const { post } = Astro.props;
-
 
 const { properties: data } = post.data;
 // Astro 6+ removed `Astro.locals.runtime.env`; bindings come from `cloudflare:workers`.
 if (post.data.cover?.type === "file") {
   const image = await env.IMAGES.head(`/thumbnail/${post.id}`);
   if (!image) {
-    
     await env.CRALWER_QUEUE.send({
       type: "image",
       url: post.data.cover.file.url,
@@ -23,26 +20,21 @@ if (post.data.cover?.type === "file") {
     });
   }
 }
+const thumbSrc =
+  post.data.cover?.type === "file"
+    ? (process.env.NODE_ENV === "production"
+        ? `${env.CDN_URL}/cdn-cgi/image/width=400/thumbnail/${post.id}`
+        : post.data.cover.file.url)
+    : undefined;
+const dateLabel = data.날짜?.start
+  ? new Intl.DateTimeFormat("ko-KR").format(data.날짜.start)
+  : null;
 ---
 
-<a href={`/news/post/${post.id}`} class={styles.link}>
-  <article class={styles.card}>
-    <div class={styles.content}>
-      {post.data.cover?.type === "file" && (
-        <div class={styles["image-container"]}>
-          <img 
-            src={process.env.NODE_ENV === "production" ? `${env.CDN_URL}/cdn-cgi/image/width=400/thumbnail/${post.id}` : post.data.cover.file.url}
-            alt=""
-          />
-        </div>
-      )}
-      <div class={styles.text}>
-        <h2 class={styles.title}>{data.이름}</h2>
-        <p class={styles.date}>
-          {data.날짜?.start ? new Intl.DateTimeFormat('ko-KR').format(
-            data.날짜.start,
-          ) : null}</p>
-      </div>
-    </div>
-  </article>
+<a href={`/news/post/${post.id}`} class={styles.row}>
+  <span class={styles.thumb}>
+    {thumbSrc ? <img src={thumbSrc} alt="" loading="lazy" /> : "thumbnail"}
+  </span>
+  <span class={styles.title}>{data.이름}</span>
+  {dateLabel && <span class={styles.date}>{dateLabel}</span>}
 </a>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -25,8 +25,8 @@
     <input
       class="munja-input"
       type="search"
-      placeholder="검색"
-      aria-label="검색"
+      placeholder="뉴스레터 검색…"
+      aria-label="뉴스레터 검색"
       autocomplete="off"
       spellcheck="false"
     />
@@ -144,31 +144,29 @@
   .munja-search {
     position: relative;
     width: 100%;
-    max-width: 34rem;
     margin: 0 auto;
   }
 
   .munja-field {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    padding: 0 1.1rem;
-    height: 3rem;
-    background: var(--card-bg, #fff);
-    border: 1px solid var(--border-color, #e2e8f0);
-    border-radius: 9999px;
-    box-shadow: var(--shadow-sm, 0 1px 2px rgb(0 0 0 / 0.05));
+    gap: 0.7rem;
+    padding: 0 16px;
+    height: 48px;
+    background: var(--card, #fff);
+    border: 1px solid var(--line, #e2e8f0);
+    border-radius: 10px;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
   }
   .munja-field:focus-within {
-    border-color: var(--primary-color, #4f46e5);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color, #4f46e5) 22%, transparent);
+    border-color: var(--accent, #4f46e5);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #4f46e5) 18%, transparent);
   }
   .munja-icon {
     flex: none;
-    width: 1.15rem;
-    height: 1.15rem;
-    color: var(--muted-color, #64748b);
+    width: 1rem;
+    height: 1rem;
+    color: var(--muted, #64748b);
   }
   .munja-input {
     flex: 1;
@@ -176,8 +174,9 @@
     height: 100%;
     border: 0;
     background: transparent;
-    color: var(--foreground, #0f172a);
-    font-size: 1rem;
+    color: var(--ink, #0f172a);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 14px;
     outline: none;
   }
   .munja-input::placeholder {

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -19,12 +19,11 @@ const list = collection
       (a.data.properties.날짜?.start.getTime() ?? 0),
   )
   .slice(0, 8);
-const length = collection.length;
 ---
 
 <Layout
   pageTitle={"Ones To Watch for FrontEnd"}
-  description={"프론트엔드에 대한 정보들을 매주 큐레이션해드립니다."}
+  description={"프론트엔드에 대한 정보들을 매주 큐레이션해드립니다."}
 >
   <Fragment slot="head">
     <meta
@@ -32,219 +31,59 @@ const length = collection.length;
       content="매주 프론트엔드 소식을 정리해서 보내드립니다."
     />
   </Fragment>
-  <article class="hero-wrapper section">
-    <div class="container hero-content">
-      <h1 class="title">
-        <Favicon class="logo" />
-        <span class="text"
-          >Ones To Watch <span class="sub">for</span> FrontEnd</span
-        >
-      </h1>
-      <h2 class="description">주목할 만한 블로그를 모아두는 웹사이트</h2>
-      <div class="cta-group">
-        <a href="/news/list/1" class="cta-button primary">
-          뉴스레터 보러가기
-        </a>
+
+  <main class="home">
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-text">
+        <p class="mono-eyebrow hero-eyebrow">// weekly frontend newsletter</p>
+        <h1 class="hero-title">Ones To Watch<br />for FrontEnd</h1>
+        <p class="hero-sub">주목할 만한 블로그를 모아두는 웹사이트</p>
+        <div class="hero-subscribe">
+          <script
+            async
+            data-uid="c7b118d8c2"
+            src="https://ones-to-watch-for-frontend.kit.com/c7b118d8c2/index.js"
+          ></script>
+        </div>
+        <p class="hero-fineprint">주 1회 발행 · 광고 없음 · 언제든 해지</p>
       </div>
-      <div class="hero-search">
+      <Favicon class="hero-logo" />
+    </section>
+
+    <!-- Features -->
+    <section class="features">
+      <div class="features-inner">
+        <div class="feature">
+          <p class="feature-num">01</p>
+          <h3 class="feature-title">Deep Insights</h3>
+          <p class="feature-desc">기술적인 깊이가 있거나 방향성을 고민하게 만드는 글</p>
+        </div>
+        <div class="feature">
+          <p class="feature-num">02</p>
+          <h3 class="feature-title">Curated Archive</h3>
+          <p class="feature-desc">주 1회 발행되는 프론트엔드 아카이브</p>
+        </div>
+        <div class="feature">
+          <p class="feature-num">03</p>
+          <h3 class="feature-title">Developer Focused</h3>
+          <p class="feature-desc">프론트엔드 개발자에게 영감을 주는 인사이트</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Recent -->
+    <section class="recent">
+      <div class="recent-head">
+        <h2 class="recent-title">최근 뉴스레터</h2>
+        <a class="recent-all" href="/news/list/1">전체 보기 →</a>
+      </div>
+      <div class="recent-search">
         <Search />
       </div>
-    </div>
-  </article>
-
-  <article class="feature-section">
-    <div class="feature-item">
-      <div class="feature-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          pathLength="1"
-        >
-          <circle cx="11" cy="11" r="8" pathLength="1"></circle>
-          <line x1="21" y1="21" x2="16.65" y2="16.65" pathLength="1"></line>
-          <line x1="11" y1="8" x2="11" y2="14" pathLength="1"></line>
-          <line x1="8" y1="11" x2="14" y2="11" pathLength="1"></line>
-        </svg>
+      <div class="post-list">
+        {list.map((post) => <Post post={post} />)}
       </div>
-      <div class="feature-text">
-        <h3 class="feature-title">Deep Insights</h3>
-        <p class="feature-desc">
-          기술적인 깊이가 있거나<br />방향성을 고민하게 만드는 글
-        </p>
-      </div>
-      <div class="feature-bottom"></div>
-    </div>
-    <div class="feature-item">
-      <div class="feature-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          pathLength="1"
-        >
-          <path
-            d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
-            pathLength="1"></path>
-          <polyline points="14 2 14 8 20 8" pathLength="1"></polyline>
-          <line x1="16" y1="13" x2="8" y2="13" pathLength="1"></line>
-          <line x1="16" y1="17" x2="8" y2="17" pathLength="1"></line>
-          <polyline points="10 9 9 9 8 9" pathLength="1"></polyline>
-        </svg>
-      </div>
-      <div class="feature-text">
-        <h3 class="feature-title">Curated Archive</h3>
-        <p class="feature-desc">주 1회 발행되는<br />프론트엔드 아카이브</p>
-      </div>
-      <div class="feature-bottom"></div>
-    </div>
-    <div class="feature-item">
-      <div class="feature-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          pathLength="1"
-        >
-          <polyline points="16 18 22 12 16 6" pathLength="1"></polyline>
-          <polyline points="8 6 2 12 8 18" pathLength="1"></polyline>
-        </svg>
-      </div>
-      <div class="feature-text">
-        <h3 class="feature-title">Developer Focused</h3>
-        <p class="feature-desc">
-          프론트엔드 개발자에게<br />영감을 주는 인사이트
-        </p>
-      </div>
-      <div class="feature-bottom"></div>
-    </div>
-  </article>
-  <article class="container card-section">
-    <h3 class="card-section-title">최근 뉴스레터</h3>
-    <ul class="card-grid">
-      {list.map((post) => <Post post={post} />)}
-    </ul>
-    <div class="newsletter-form">
-      <div class="form-title">이메일로 받아보기</div>
-      <script
-        async
-        data-uid="c7b118d8c2"
-        src="https://ones-to-watch-for-frontend.kit.com/c7b118d8c2/index.js"
-      ></script>
-    </div>
-  </article>
-
-  <div class="sticky-cta" id="sticky-cta">
-    <a href="/news/list/1" class="sticky-cta-button"> 뉴스레터 보러가기 </a>
-  </div>
-
-  <script>
-    // Feature scroll animation
-    const features = document.querySelectorAll(".feature-item .feature-bottom");
-    if (features.length > 0) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              (entry.target.parentNode as HTMLElement)?.classList.add(
-                "visible",
-              );
-            }
-          });
-        },
-        { threshold: 0.2 },
-      );
-
-      features.forEach((feature) => observer.observe(feature));
-    }
-
-    // Sticky CTA button - optimized with IntersectionObserver instead of scroll event
-    const stickyCta = document.getElementById("sticky-cta");
-    const heroSection = document.querySelector(".section");
-
-    if (stickyCta && heroSection) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (!entry.isIntersecting && entry.boundingClientRect.top < 0) {
-              // Hero section has scrolled past the top
-              stickyCta.classList.add("visible");
-            } else {
-              stickyCta.classList.remove("visible");
-            }
-          });
-        },
-        { threshold: 0, rootMargin: "0px 0px 0px 0px" },
-      );
-
-      observer.observe(heroSection);
-    }
-
-    // GSAP Button Animation
-    import { gsap } from "gsap";
-
-    const ctaButton = document.querySelector(".cta-button") as HTMLElement;
-    const cardSection = document.querySelector(".card-section");
-
-    if (ctaButton && cardSection) {
-      ctaButton.addEventListener("click", (e) => {
-        e.preventDefault();
-
-        // 1. Shake animation
-        const shakeTimeline = gsap.timeline();
-
-        shakeTimeline
-          .to(ctaButton, {
-            x: -20,
-            duration: 0.1,
-            repeat: 5,
-            yoyo: true,
-            ease: "power1.inOut",
-          })
-          .to(ctaButton, {
-            x: 0,
-            duration: 0.1,
-            onComplete: () => {
-              // 2. Fall animation
-              gsap.to(ctaButton, {
-                y: 500,
-                opacity: 0,
-                rotation: 45,
-                duration: 0.8,
-                ease: "power2.in",
-                onComplete: () => {
-                  // 3. Scroll to section
-                  cardSection.scrollIntoView({
-                    behavior: "smooth",
-                    block: "start",
-                  });
-
-                  // (Optional) Reset button after a delay if user scrolls back up
-                  setTimeout(() => {
-                    gsap.set(ctaButton, {
-                      y: 0,
-                      opacity: 1,
-                      rotation: 0,
-                      clearProps: "all",
-                    });
-                  }, 2000);
-                },
-              });
-            },
-          });
-      });
-    }
-  </script>
+    </section>
+  </main>
 </Layout>

--- a/src/pages/news/list/[page].astro
+++ b/src/pages/news/list/[page].astro
@@ -7,63 +7,45 @@ import "@/styles/list-page.css";
 
 export const prerender = false;
 const { page } = Astro.params;
-// 
 const collection = await getCollection('news');
 if (!Number.isSafeInteger(Number(page)) || !collection) {
   return Astro.redirect('/404');
 }
 const validatedPage = Number(page as string);
 
-const list = collection.sort(
-  (a, b) => (b.data.properties.날짜?.start.getTime() ?? 0) - (a.data.properties.날짜?.start.getTime() ?? 0))
-  .slice(12 * (validatedPage - 1), 12 * validatedPage);
+const sorted = collection.sort(
+  (a, b) => (b.data.properties.날짜?.start.getTime() ?? 0) - (a.data.properties.날짜?.start.getTime() ?? 0));
+const list = sorted.slice(12 * (validatedPage - 1), 12 * validatedPage);
 const length = collection.length;
+const hasPrev = validatedPage > 1;
+const hasNext = length > 12 * validatedPage;
 ---
 
-<Layout pageTitle={`${page}페이지 | OTW for FE`}>
-    <div class="container">
-      <div class="list-search">
-        <Search />
-      </div>
-      <ul
-        class="article-grid"
-      >
-        {
-          list.map((post) => (
-            <Post post={post} />
-          ))
-        }
-      </ul>
-      <nav class="pagination-list">
-        <div>
-          {
-            validatedPage > 1 ? (
-              <a
-                class="pagination-previous"
-                href={`/news/list/${(validatedPage ?? 0) - 1}`}
-              >
-                이전
-              </a>
-            ) : null
-          }
-        </div>
-        <div>
-          {
-            length > 12 * validatedPage ? (
-              <a
-                class="pagination-next"
-                href={`/news/list/${(validatedPage ?? 0) + 1}`}
-              >
-                다음
-              </a>
-            ) : null
-          }
-        </div>
-      </nav>
-      <div class="newsletter-form">
-        <div class="form-title">최신 정보를 놓치지 마세요!</div>
+<Layout pageTitle={`${validatedPage}페이지 | OTW for FE`}>
+  <main class="archive">
+    <p class="mono-eyebrow">// archive</p>
+    <h1 class="archive-title">뉴스레터 아카이브</h1>
 
-        <script async data-uid="c7b118d8c2" src="https://ones-to-watch-for-frontend.kit.com/c7b118d8c2/index.js"></script>
-      </div>
+    <div class="archive-search">
+      <Search />
     </div>
+
+    <div class="post-list">
+      {list.map((post) => <Post post={post} />)}
+    </div>
+
+    <nav class="pager">
+      {hasPrev ? (
+        <a class="pager-btn" href={`/news/list/${validatedPage - 1}`}>← 이전</a>
+      ) : (
+        <span></span>
+      )}
+      <span class="pager-current">{validatedPage}</span>
+      {hasNext ? (
+        <a class="pager-btn" href={`/news/list/${validatedPage + 1}`}>다음 →</a>
+      ) : (
+        <span></span>
+      )}
+    </nav>
+  </main>
 </Layout>

--- a/src/styles/components/header.module.css
+++ b/src/styles/components/header.module.css
@@ -1,8 +1,8 @@
 .container {
   width: 100%;
-  max-width: 1200px;
+  max-width: 880px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 2rem;
 }
 
 /* Header styles */
@@ -20,10 +20,10 @@
 .container {
   display: flex;
   width: 100%;
-  max-width: 1200px;
+  max-width: 880px;
   margin: 0 auto;
-  padding: 0 1rem;
-  height: 4.5rem;
+  padding: 0 2rem;
+  height: 4rem;
   align-items: center;
   justify-content: space-between;
 }
@@ -45,8 +45,9 @@
 .logo {
   display: flex;
   align-items: center;
-  font-size: 1.25rem;
-  font-weight: 900;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   text-decoration: none;
   color: var(--foreground);
   transition: all 0.2s ease;

--- a/src/styles/components/post.module.css
+++ b/src/styles/components/post.module.css
@@ -1,129 +1,85 @@
-.card {
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
-  padding: 1.5rem;
-  border-radius: 1.5rem;
-  border: 1px solid transparent;
-  background: var(--card-bg, white);
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-  box-shadow: var(--shadow-sm);
-}
-
-/* Removed top border gradient for cleaner look */
-
-.link {
-  text-decoration: none;
-  color: inherit;
-  display: block;
-}
-
-.link:hover .card {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-lg);
-  border-color: var(--primary-color);
-}
-
-/* Removed top border hover effect */
-
-.content {
-  height: 100%;
+/* Editorial list row: thumbnail + title + mono date, divided by hairlines. */
+.row {
   display: flex;
-  gap: 1rem;
   align-items: center;
-  position: relative;
-  z-index: 2;
+  gap: 20px;
+  padding: 16px 8px;
+  border-bottom: 1px solid var(--line);
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 0.15s ease;
+}
+.row:hover {
+  background: var(--surface);
 }
 
-.image-container {
-  position: relative;
-  aspect-ratio: 16 / 9;
+.thumb {
   flex-shrink: 0;
-  border-radius: 1rem;
+  width: 160px;
+  height: 100px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
   overflow: hidden;
-  background: var(--hover-bg);
-  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--thumb-a),
+    var(--thumb-a) 6px,
+    var(--thumb-b) 6px,
+    var(--thumb-b) 12px
+  );
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
 }
-
-.image-container img {
+.thumb img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.3s ease;
-
-  &:not([src]) {
-    visibility: hidden;
-  }
 }
-
-.link:hover .image-container img {
-  transform: scale(1.05);
-}
-
-.text {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  min-width: 0;
-  height: 100%;
-  position: relative;
-  z-index: 1;
+.thumb img:not([src]) {
+  visibility: hidden;
 }
 
 .title {
-  font-size: 1.25rem;
-  font-weight: 700;
-  margin: auto 0 0.5rem 0;
-  line-height: 1.4;
-  color: var(--foreground);
-  letter-spacing: -0.01em;
-  /* Ensure text doesn't overflow */
+  flex: 1;
+  min-width: 0;
+  font-size: 16.5px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--ink);
+  text-wrap: pretty;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
-  line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 
 .date {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--muted-color, #64748b);
-  margin: 0 0 auto;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--muted);
+  white-space: nowrap;
 }
 
-/* Mobile styles */
-@media (max-width: 768px) {
-  .content {
-    flex-direction: row;
-    align-items: center;
+@media (max-width: 640px) {
+  .row {
+    gap: 14px;
   }
-
-  .image-container {
-    width: 160px;
+  .thumb {
+    width: 96px;
+    height: 64px;
   }
-
   .title {
-    font-size: 1rem;
+    font-size: 15px;
   }
-}
-
-/* Tablet styles */
-@media (min-width: 769px) and (max-width: 1023px) {
-  .image-container {
-    width: 180px;
-  }
-}
-
-/* Desktop styles */
-@media (min-width: 1024px) {
-  .image-container {
-    width: 280px;
-  }
-
-  .title {
-    font-size: 1.25rem;
+  .date {
+    display: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,161 +1,140 @@
-@font-face {
-  font-family: "SUITE";
-  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2304-2@1.0/SUITE-Regular.woff2") format("woff2");
-  font-weight: 400;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "SUITE";
-  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2304-2@1.0/SUITE-Bold.woff2") format("woff2");
-  font-weight: 700;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "SUITE";
-  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2304-2@1.0/SUITE-Heavy.woff2") format("woff2");
-  font-weight: 900;
-  font-style: normal;
-}
+/* Editorial redesign — IBM Plex typography + indigo/slate token system.
+   Body: IBM Plex Sans KR. Mono accents (labels, dates, // comments): IBM Plex Mono. */
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans+KR:wght@400;500;600;700&display=swap");
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: 100px;
+  scroll-padding-top: 88px;
 }
 
 :root {
-  /* Modern Blue Palette - More vivid yet professional */
-  --base-950: #0f172a;
-  /* Slate 900 */
-  --base-900: #1e293b;
-  /* Slate 800 */
-  --base-800: #334155;
-  /* Slate 700 */
-  --base-700: #475569;
-  /* Slate 600 */
-  --base-600: #4f46e5;
-  /* Indigo 600 - Primary Brand */
-  --base-500: #6366f1;
-  /* Indigo 500 */
-  --base-400: #818cf8;
-  /* Indigo 400 */
-  --base-300: #a5b4fc;
-  /* Indigo 300 */
-  --base-200: #c7d2fe;
-  /* Indigo 200 */
-  --base-100: #e0e7ff;
-  /* Indigo 100 */
-  --base-50: #f8fafc;
-  /* Slate 50 */
-}
+  --font-sans: "IBM Plex Sans KR", -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-:root {
-  /* Light theme */
-  --background: #ffffff;
-  --foreground: var(--base-950);
-  --muted-color: var(--base-700);
-  --border-color: #e2e8f0;
-  --primary-color: var(--base-600);
-  --primary-hover: var(--base-500);
-  --hover-bg: var(--base-50);
-  --card-bg: #ffffff;
-  --card-border: #f1f5f9;
-  --header-bg: rgba(255, 255, 255, 0.8);
-  --mobile-nav-bg: rgba(255, 255, 255, 0.95);
+  /* Core editorial tokens — light (default). */
+  --bg: #ffffff;
+  --surface: #f8fafc;
+  --line: #e2e8f0;
+  --ink: #0f172a;
+  --muted: #475569;
+  --accent: #4f46e5;
+  --accent-ink: #4338ca;
+  --card: #ffffff;
+  --thumb-a: #e0e7ff;
+  --thumb-b: #eef2ff;
+
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  /* Back-compat aliases: existing component CSS still reads these names. They
+     reference the core tokens above, so a theme switch updates them for free. */
+  --background: var(--bg);
+  --foreground: var(--ink);
+  --muted-color: var(--muted);
+  --border-color: var(--line);
+  --primary-color: var(--accent);
+  --primary-hover: var(--accent-ink);
+  --hover-bg: var(--surface);
+  --card-bg: var(--card);
+  --card-border: var(--line);
+  --header-bg: var(--bg);
+  --mobile-nav-bg: var(--bg);
 }
 
+/* Dark tokens — applied by the explicit toggle. Only the core tokens change;
+   the aliases above follow automatically. */
+[data-theme="dark"] {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --line: #334155;
+  --ink: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #818cf8;
+  --accent-ink: #a5b4fc;
+  --card: #1e293b;
+  --thumb-a: #1e293b;
+  --thumb-b: #263449;
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.4);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
+}
+
+/* System-preference dark, unless the user explicitly picked light. */
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: var(--base-950);
-    --foreground: #f8fafc;
-    --muted-color: #94a3b8;
-    --border-color: var(--base-800);
-    --primary-color: var(--base-400);
-    --primary-hover: var(--base-300);
-    --hover-bg: var(--base-900);
-    --card-bg: var(--base-900);
-    --card-border: var(--base-800);
-    --header-bg: rgba(15, 23, 42, 0.8);
-    --mobile-nav-bg: rgba(15, 23, 42, 0.95);
+  :root:not([data-theme="light"]) {
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --line: #334155;
+    --ink: #f8fafc;
+    --muted: #94a3b8;
+    --accent: #818cf8;
+    --accent-ink: #a5b4fc;
+    --card: #1e293b;
+    --thumb-a: #1e293b;
+    --thumb-b: #263449;
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.4);
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
   }
 }
 
-[data-theme="dark"] {
-  --background: var(--base-950);
-  --foreground: #f8fafc;
-  --muted-color: #94a3b8;
-  --border-color: var(--base-800);
-  --primary-color: var(--base-400);
-  --primary-hover: var(--base-300);
-  --hover-bg: var(--base-900);
-  --card-bg: var(--base-900);
-  --card-border: var(--base-800);
-  --header-bg: rgba(15, 23, 42, 0.8);
-  --mobile-nav-bg: rgba(15, 23, 42, 0.95);
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.4);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
-}
-
-[data-theme="light"] {
-  --background: #ffffff;
-  --foreground: var(--base-950);
-  --muted-color: var(--base-700);
-  --border-color: #e2e8f0;
-  --primary-color: var(--base-600);
-  --primary-hover: var(--base-500);
-  --hover-bg: var(--base-50);
-  --card-bg: #ffffff;
-  --card-border: #f1f5f9;
-  --header-bg: rgba(255, 255, 255, 0.8);
-  --mobile-nav-bg: rgba(255, 255, 255, 0.95);
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-}
-
 html,
 body {
   margin: 0;
   padding: 0;
-  font-family: "SUITE", -apple-system, BlinkMacSystemFont, Apple SD Gothic Neo, "sans-serif";
-  background-color: var(--background);
-  color: var(--foreground);
+  font-family: var(--font-sans);
+  background-color: var(--bg);
+  color: var(--ink);
 }
 
 body {
-  margin: 0;
   min-height: 100vh;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
-}
-
-.container {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 * {
   box-sizing: border-box;
 }
 
-.sr-only {
-  display: none;
-}
-
 a {
-  color: var(--base-500);
+  color: inherit;
+  text-decoration: none;
 }
 
-main>.markdown-body {
+.container {
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+/* Mono eyebrow used across pages, e.g. "// weekly frontend newsletter". */
+.mono-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  margin: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+main > .markdown-body {
   padding: 0 1rem;
-  background-color: var(--background);
+  background-color: var(--bg);
+}
+.markdown-body a {
+  color: var(--accent);
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,338 +1,165 @@
-/* Hero Section */
-.hero-wrapper {
-  position: relative;
-  width: 100%;
-  /* Default block behavior */
-  padding-top: 4rem;
-  padding-bottom: 4rem;
+/* Home — editorial layout. Body font is IBM Plex Sans KR (global); mono accents
+   use var(--font-mono). Content column is 880px, matching the header. */
 
-  /* Ensure gradient covers everything */
-  background: radial-gradient(circle at 50% 30%, var(--base-200), transparent 70%),
-    radial-gradient(circle at 80% 10%, var(--base-100), transparent 50%);
-  background-size: cover;
-  background-attachment: fixed;
+@keyframes heroIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-/* Fix Hero Background Cutoff Attempt 2:
-   If the element is inside a restricted width container, the background is restricted.
-   We should probably fix the HTML to allow fullbleed, but let's try to fix it here with a pseudo-element
-   that is absolutely positioned to viewport if permissible, or just accept it's contained.
-   The user said "background is cut off", implying they want full width.
-   Let's assume the gradient should extend.
-*/
-
-.hero-content {
-  position: relative;
-  z-index: 10;
+.home {
+  display: block;
 }
 
-.title {
+/* Hero */
+.hero {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 96px 32px 72px;
   display: flex;
-  flex-direction: column;
-  row-gap: 1rem;
   align-items: center;
-  margin-bottom: 2rem;
-  font-size: 2.5rem;
-  line-height: 1.1;
-  font-weight: 900;
-  text-align: center;
-  justify-content: center;
-  color: var(--foreground);
-
-  @media (min-width: 1024px) {
-    row-gap: 0;
-    font-size: 4.5rem;
-    line-height: 1;
-    letter-spacing: -0.03em;
-  }
-
-  &>.logo {
-    display: block;
-    width: 4rem;
-    height: 4rem;
-    margin-bottom: 1rem;
-
-    @media (min-width: 1024px) {
-      width: 7rem;
-      height: 7rem;
-      margin-bottom: 1.5rem;
-      margin-right: 0;
-    }
-  }
-
-  & .text {
-    display: inline-flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    max-width: 900px;
-  }
-
-  & .sub {
-    margin: auto .375rem;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--muted-color);
-
-    @media (min-width: 1024px) {
-      margin: auto .75rem 0;
-      font-size: 2.5rem;
-    }
-  }
+  gap: 48px;
 }
-
-.description {
-  margin-bottom: 3.5rem;
-  font-size: 1.25rem;
-  font-weight: 500;
-  text-align: center;
-  color: var(--foreground);
-  /* Changed from muted-color to foreground for visibility */
+.hero-text {
+  flex: 1;
+  min-width: 0;
+}
+.hero-eyebrow {
+  margin: 0 0 20px;
+  animation: heroIn 0.6s ease both;
+}
+.hero-title {
+  font-size: 54px;
+  line-height: 1.12;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0 0 20px;
+  color: var(--ink);
+  text-wrap: pretty;
+  animation: heroIn 0.7s ease 0.1s both;
+}
+.hero-sub {
+  font-size: 19px;
+  line-height: 1.7;
+  color: var(--muted);
+  margin: 0 0 32px;
+  max-width: 520px;
+  text-wrap: pretty;
+  animation: heroIn 0.7s ease 0.2s both;
+}
+.hero-subscribe {
+  max-width: 460px;
+  animation: heroIn 0.7s ease 0.3s both;
+}
+.hero-fineprint {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted);
+  margin: 14px 0 0;
+}
+.hero-logo {
+  width: 220px;
+  height: 220px;
+  flex-shrink: 0;
+  color: var(--accent);
   opacity: 0.9;
-  max-width: 40rem;
-  margin-left: auto;
-  margin-right: auto;
-  word-break: keep-all;
-
-  @media (min-width: 1024px) {
-    font-size: 1.75rem;
-  }
+  transition: filter 0.3s ease, transform 0.3s ease;
+}
+.hero-logo:hover {
+  filter: drop-shadow(0 8px 24px rgba(79, 70, 229, 0.45));
+  transform: translateY(-4px);
 }
 
-.cta-group {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
+/* Features */
+.features {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+  transition: background-color 0.3s ease;
 }
-
-.hero-search {
-  margin-top: 2rem;
-  padding: 0 1rem;
-}
-
-.cta-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1rem 2.5rem;
-  font-size: 1.125rem;
-  font-weight: 700;
-  border-radius: 9999px;
-  text-decoration: none;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  /* Enhanced shadow */
-
-  &.primary {
-    color: white;
-    background-color: var(--primary-color);
-    border: 1px solid transparent;
-
-    &:hover {
-      background-color: var(--primary-hover);
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-lg);
-    }
-  }
-
-  &.secondary {
-    color: var(--foreground);
-    background-color: var(--background);
-    border: 1px solid var(--border-color);
-
-    &:hover {
-      background-color: var(--hover-bg);
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
-      border-color: var(--primary-color);
-    }
-  }
-}
-
-/* Feature Section */
-.feature-section {
-  padding: 0;
-  max-width: 100%;
-}
-
-.feature-item {
-  min-height: auto;
-  /* Remove fixed height constraint */
-  padding: 4rem 1rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transform: translateY(30px);
-  transition: opacity 1s ease, transform 1s ease;
-
-  &.visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  /* Add subtle background to odd items to differentiate */
-  &:nth-child(odd) {
-    background-color: var(--background);
-  }
-
-  &:nth-child(even) {
-    background-color: var(--hover-bg);
-  }
-
-  .feature-bottom {
-    height: 1px;
-  }
-}
-
-.feature-icon {
-  margin-bottom: 1.5rem;
-  color: var(--primary-color);
-
-  & svg {
-    width: 6rem;
-    height: 6rem;
-    stroke-width: 1.5;
-
-    @media (min-width: 1024px) {
-      width: 8rem;
-      height: 8rem;
-    }
-
-    & path,
-    & circle,
-    & line,
-    & polyline {
-      /* With pathLength="1" in SVG, we can use 1 for full length */
-      stroke-dasharray: 1;
-      stroke-dashoffset: 1;
-      transition: stroke-dashoffset 1.5s cubic-bezier(0.25, 1, 0.5, 1);
-    }
-  }
-}
-
-.feature-item.visible .feature-icon svg {
-
-  & path,
-  & circle,
-  & line,
-  & polyline {
-    stroke-dashoffset: 0;
-  }
-}
-
-@keyframes draw {
-  to {
-    stroke-dashoffset: 0;
-  }
-}
-
-.feature-text {
-  text-align: center;
-  max-width: 800px;
-}
-
-.feature-title {
-  font-size: 2.5rem;
-  font-weight: 900;
-  margin-bottom: 2rem;
-  color: var(--primary-color);
-  letter-spacing: -0.02em;
-
-  @media (min-width: 1024px) {
-    font-size: 4rem;
-  }
-}
-
-.feature-desc {
-  font-size: 1.5rem;
-  line-height: 1.6;
-  color: var(--foreground);
-  word-break: keep-all;
-
-  @media (min-width: 1024px) {
-    font-size: 2rem;
-  }
-}
-
-.newsletter-form {
-  /* Removed border-top that was copied from sticky-cta */
-  margin-top: 4rem;
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-radius: 1.5rem;
-  box-shadow: var(--shadow-lg);
-  width: 100%;
-  max-width: 32rem;
-  margin-left: auto;
-  margin-right: auto;
-
-  & .form-title {
-    font-size: 1.25rem;
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 1.5rem;
-    color: var(--foreground);
-
-    @media (min-width: 1024px) {
-      font-size: 1.5rem;
-    }
-  }
-}
-
-.sticky-cta {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 1rem;
-  background: var(--background);
-  border-top: none;
-  /* Removed border */
-  transform: translateY(100%);
-  transition: transform 0.3s ease;
-  z-index: 1000;
-  text-align: center;
-
-  &.visible {
-    transform: translateY(0);
-  }
-}
-
-.sticky-cta-button {
-  display: inline-block;
-  padding: 0.75rem 2rem;
-  font-size: 1rem;
-  font-weight: 700;
-  color: white;
-  background-color: var(--primary-color);
-  border: 1px solid transparent;
-  border-radius: 9999px;
-  text-decoration: none;
-  transition: all 0.2s ease;
-  box-shadow: var(--shadow-md);
-
-  &:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-lg);
-  }
-}
-
-.card-grid {
-  padding: 0;
+.features-inner {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 56px 32px;
   display: grid;
-  gap: 2rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px;
+}
+.feature-num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  margin: 0 0 10px;
+}
+.feature-title {
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  color: var(--ink);
+}
+.feature-desc {
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin: 0;
+  word-break: keep-all;
+}
 
-  @media (min-width: 769px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 2.5rem;
+/* Recent */
+.recent {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 72px 32px 96px;
+}
+.recent-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.recent-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--ink);
+}
+.recent-all {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.recent-search {
+  margin-bottom: 20px;
+}
+
+/* Shared post list (also used on the archive page) */
+.post-list {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    flex-direction: column-reverse;
+    align-items: flex-start;
+    padding: 64px 24px 48px;
+    gap: 28px;
+  }
+  .hero-logo {
+    width: 120px;
+    height: 120px;
+  }
+  .hero-title {
+    font-size: 40px;
+  }
+  .features-inner {
+    grid-template-columns: 1fr;
+    gap: 28px;
+    padding: 40px 24px;
+  }
+  .recent {
+    padding: 48px 24px 72px;
   }
 }

--- a/src/styles/list-page.css
+++ b/src/styles/list-page.css
@@ -1,79 +1,68 @@
-
-.container {
-  width: 100%;
-  max-width: 1200px;
+/* News archive — mono eyebrow, title, search, editorial post list, pager. */
+.archive {
+  max-width: 880px;
   margin: 0 auto;
-  padding: 0 1rem;
-  @media (min-width: 768px) {
-    & {
-      padding: 0 1.5rem;
-    }
-  }
+  padding: 72px 32px 96px;
 }
-.list-search {
-  margin: 2rem 0 1rem;
+.archive-title {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 14px 0 32px;
+  color: var(--ink);
 }
-
-.article-grid {
-  margin: 0;
-  padding: 2rem 0;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(1, 1fr);
-  @media (min-width: 769px) {
-    & {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
+.archive-search {
+  margin-bottom: 32px;
 }
 
-.pagination-list {
+.post-list {
   display: flex;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  justify-content: space-between;
+  flex-direction: column;
 }
-.pagination-previous,
-.pagination-next {
+
+/* Pager */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 48px;
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+}
+.pager-current {
+  min-width: 38px;
+  height: 38px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.5rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--border-color, #e2e8f0);
-  background-color: var(--background, white);
-  color: var(--foreground);
-  text-decoration: none;
-  transition: all 0.2s ease;
+  padding: 0 12px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
 }
-
-
-.pagination-previous,
-.pagination-next {
-  padding: 0.5rem 1rem;
-}
-
-.pagination-previous:hover,
-.pagination-next:hover {
-  background-color: var(--hover-bg, #f8fafc);
-}
-
-.newsletter-form {
-  margin-top: 4rem;
-  display: flex;
-  flex-direction: column;
+.pager-btn {
+  height: 38px;
+  padding: 0 16px;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  & .form-title {
-    font-size: 1.75rem;
-    text-align: center;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.pager-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .archive {
+    padding: 48px 24px 72px;
   }
-  & > * {
-    width: 100%;
+  .archive-title {
+    font-size: 28px;
   }
 }


### PR DESCRIPTION
첨부해주신 리디자인 목업 기반으로 사이트 비주얼을 전면 교체했습니다. **검색 PR(#14) 위에 쌓인 스택 PR**이라 base가 `feat/munja-search`입니다(그쪽 머지 후 자동으로 master 대상으로 바뀝니다).

## 디자인 시스템
- **폰트**: `IBM Plex Sans KR`(본문) + `IBM Plex Mono`(라벨·날짜·`// 주석`·페이지네이션·숫자)
- **토큰(global.css)**: 목업 팔레트로 재정의 — `--bg/--surface/--line/--ink/--muted/--accent/--accent-ink/--card/--thumb-*`. 기존 컴포넌트 CSS가 쓰던 옛 변수명(`--background`, `--foreground`, `--primary-color`…)은 **코어 토큰을 참조하는 별칭**으로 남겨, 손 안 댄 곳도 자동 리컬러 + 다크토글 자동 추종.
- 라이트/다크 **테마 토글 유지**(기존 `data-theme` 방식 그대로).

## 페이지별
- **헤더**: 880px 폭, 64px 높이, 솔리드 서피스로 슬림하게.
- **홈**: 2단 히어로(모노 eyebrow `// weekly frontend newsletter` + 큰 타이틀 + 인라인 구독 + 카메라 로고), **01/02/03 넘버 피처**(서피스 밴드), `최근 뉴스레터` + 검색 + **에디토리얼 리스트**.
- **아카이브(News)**: 모노 `// archive` eyebrow, 검색, 리스트, 모노 페이저.
- **Post 카드 → 리스트 행**: 썸네일 + 제목 + 모노 날짜, 헤어라인 구분선(그리드 카드 제거).
- **검색창**: 모노·라운드·풀폭으로 재스타일, placeholder `뉴스레터 검색…`.

## 유지된 기능
Notion 썸네일 파이프라인, kit.com 구독 폼, munja 검색 + `?q=` 하이라이팅 모두 그대로.

## 범위/확인 필요
- **글 상세 페이지**는 구조는 그대로 두고 새 토큰·폰트만 상속(TOC/북마크/giscus/하이라이팅 로직 보존). 필요하면 목업의 목차 카드 스타일까지 별도로 맞출 수 있습니다.
- 이 환경에선 `astro build`가 Notion 시크릿·CF 바인딩 필요라 **빌드/시각 확인 불가** → 프리뷰 재배포로 확인 부탁드립니다. 특히 히어로의 kit.com 구독 위젯은 자체 UI라 목업의 커스텀 입력창과 완전 일치하진 않을 수 있어요(원하면 커스텀 폼으로 교체 가능).